### PR TITLE
ci: use fixed version for traefik

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -254,7 +254,7 @@ services:
       - netbox-postgres-data:/var/lib/postgresql/data
 
   traefik:
-    image: traefik:latest
+    image: traefik:v3
     command:
       - --api=true
       - --api.insecure=true


### PR DESCRIPTION
instead of using the latest tag use v3

latest can change to the next major version and thus bring breaking changes
instead choose the current major version and only make the jump manually, but still get all the fixes automatically