### PR TITLE
docs: consistent config file naming, explain token

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ To configure the environment variables, modify the values as needed in the `.env
 docker compose -f dev/docker-compose.yml logs netbox-setup
 ```
 
+Set the retrieved value in `assets/plugin_configs/data_source/asset/netbox-local.toml` for the parameter `api_token`.
+
 Proceed with:
 
 - [Authenticate with the API](#authenticate-with-the-api)
@@ -100,18 +102,18 @@ Before starting the services, make sure to configure the plugins and the APIs ac
 
 ### Configure Plugins
 
-To configure the Netbox fetcher plugin, copy the file [`assets/plugin_configs/data_source/asset/sample/netbox.toml`](assets/plugin_configs/data_source/asset/sample/netbox.toml) to `assets/plugin_configs/data_source/asset/netbox_local.toml` and adjust the values to your environment.
+To configure the Netbox fetcher plugin, copy the file [`assets/plugin_configs/data_source/asset/sample/netbox.toml`](assets/plugin_configs/data_source/asset/sample/netbox.toml) to `assets/plugin_configs/data_source/asset/netbox-local.toml` and adjust the values to your environment.
 The file can be named any way you like, but it must be a toml file.
 
 ```shell
-cp assets/plugin_configs/data_source/asset/sample/netbox.toml assets/plugin_configs/data_source/asset/netbox_local.toml
+cp assets/plugin_configs/data_source/asset/sample/netbox.toml assets/plugin_configs/data_source/asset/netbox-local.toml
 ```
 
-To configure the ISDuBA fetcher plugin, copy the file [`assets/plugin_configs/data_source/csaf/sample/isduba.toml`](assets/plugin_configs/data_source/csaf/sample/isduba.toml) to `assets/plugin_configs/data_source/csaf/isduba_local.toml` and adjust the values to your environment.
+To configure the ISDuBA fetcher plugin, copy the file [`assets/plugin_configs/data_source/csaf/sample/isduba.toml`](assets/plugin_configs/data_source/csaf/sample/isduba.toml) to `assets/plugin_configs/data_source/csaf/isduba-local.toml` and adjust the values to your environment.
 The file can be named any way you like, but it must be a toml file.
 
 ```shell
-cp assets/plugin_configs/data_source/csaf/sample/isduba.toml assets/plugin_configs/data_source/csaf/isduba_local.toml
+cp assets/plugin_configs/data_source/csaf/sample/isduba.toml assets/plugin_configs/data_source/csaf/isduba-local.toml
 ```
 
 Before starting the synchronizers, make sure to create some assets and CSAF documents in the NetBox and ISDuBA instances.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -133,13 +133,13 @@ Quick start
    - NetBox fetcher (asset source):
 
      - Copy: ``assets/plugin_configs/data_source/asset/sample/netbox.toml``
-       to a new file in ``assets/plugin_configs/data_source/asset/`` (e.g. ``netbox_local.toml``)
+       to a new file in ``assets/plugin_configs/data_source/asset/`` (e.g. ``netbox-local.toml``)
      - Set ``url`` (e.g. http://netbox.localhost/) and ``api_token`` (see token from setup logs)
 
    - ISDuBA fetcher (CSAF source):
 
      - Copy: ``assets/plugin_configs/data_source/csaf/sample/isduba.toml``
-       to a new file in ``assets/plugin_configs/data_source/csaf/`` (e.g. ``isduba_local.toml``)
+       to a new file in ``assets/plugin_configs/data_source/csaf/`` (e.g. ``isduba-local.toml``)
      - Set ``url`` (e.g. http://isduba.localhost/), ``username``/``password`` (default user/user), and
        ``keycloak_url`` (e.g. http://keycloak.localhost/)
 


### PR DESCRIPTION
the README used the names netbox_local.toml and isduba_local.toml, while the script dev/start-local-env.sh actually used netbox-local.toml and isduba-local.toml.
Harmonize the names to what is actually in use.

Also tell the user what to do with the Netbox API token, that he just read from the logs.