### PR TITLE
set dev requirement to main for DDDC plugin

### DIFF
--- a/dev/plugin_requirements.txt
+++ b/dev/plugin_requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/DINA-community/DDDC-Netbox-plugin.git@P625-2
+git+https://github.com/DINA-community/DDDC-Netbox-plugin.git
 git+https://github.com/DINA-community/CSAF-Netbox-Plugin.git


### PR DESCRIPTION
Since the branch P625-2 is in main now, the requirement should be adjusted